### PR TITLE
Don't error out if docs directory is already there

### DIFF
--- a/d/d.bzl
+++ b/d/d.bzl
@@ -359,8 +359,8 @@ def _d_docs_impl(ctx):
   doc_cmd = (
       [
           "set -e;",
-          "rm -rf %s; mkdir %s;" % (docs_dir, docs_dir),
-          "rm -rf %s; mkdir %s;" % (objs_dir, objs_dir),
+          "rm -rf %s; mkdir -p %s;" % (docs_dir, docs_dir),
+          "rm -rf %s; mkdir -p %s;" % (objs_dir, objs_dir),
           toolchain.d_compiler_path,
           "-c",
           "-D",


### PR DESCRIPTION
I don't actually have a Mac today to test this on, but it should fix http://ci.bazel.io/job/rules_d/BAZEL_VERSION=HEAD,PLATFORM_NAME=darwin-x86_64/6/console.
