### PR TITLE
Fix label depedencies of d rules.

### DIFF
--- a/d/d.bzl
+++ b/d/d.bzl
@@ -1,4 +1,4 @@
-# Copyright 2015 The Bazel Authors. All rights reserved.
+# Copyright 2015 The Bazel Authors. All rights reserved
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -404,18 +404,18 @@ _d_common_attrs = {
 
 _d_compile_attrs = {
     "_d_compiler": attr.label(
-        default = Label("@bazel_tools//tools/build_defs/d:dmd"),
+        default = Label("//d:dmd"),
         executable = True,
         single_file = True,
     ),
     "_d_stdlib": attr.label(
-        default = Label("@bazel_tools//tools/build_defs/d:libphobos2"),
+        default = Label("//d:libphobos2"),
     ),
     "_d_stdlib_src": attr.label(
-        default = Label("@bazel_tools//tools/build_defs/d:phobos-src"),
+        default = Label("//d:phobos-src"),
     ),
     "_d_runtime_import_src": attr.label(
-        default = Label("@bazel_tools//tools/build_defs/d:druntime-import-src"),
+        default = Label("//d:druntime-import-src"),
     ),
 }
 


### PR DESCRIPTION
Bazel @HEAD do not include the d package anymore so use
the repository relative label instead.

This fix the breakage on ci.bazel.io