### PR TITLE
Use Bazel mirror to download tarballs

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -12,3 +12,4 @@
 Damien Martin-Guillerez <dmarting@google.com>
 David Chen <dzc@google.com>
 Kristina Chodorow <kchodorow@google.com>
+Justine Alexandra Roberts Tunney <jart@google.com>

--- a/README.md
+++ b/README.md
@@ -19,10 +19,11 @@ To use the D rules, add the following to your `WORKSPACE` file to add the
 external repositories for the D toolchain:
 
 ```python
-git_repository(
+http_archive(
     name = "io_bazel_rules_d",
-    remote = "https://github.com/bazelbuild/rules_d.git",
-    tag = "0.0.1",
+    url = "http://bazel-mirror.storage.googleapis.com/github.com/bazelbuild/rules_d/archive/0.0.1.tar.gz",
+    sha256 = "6f83ecd38c94a8ff5a68593b9352d08c2bf618ea8f87917c367681625e2bc04e",
+    strip_prefix = "rules_d-0.0.1",
 )
 load("@io_bazel_rules_d//d:d.bzl", "d_repositories")
 

--- a/d/d.bzl
+++ b/d/d.bzl
@@ -506,14 +506,14 @@ filegroup(
 def d_repositories():
   native.new_http_archive(
       name = "dmd_linux_x86_64",
-      url = "http://downloads.dlang.org/releases/2.x/2.070.0/dmd.2.070.0.linux.tar.xz",
+      url = "http://bazel-mirror.storage.googleapis.com/downloads.dlang.org/releases/2.x/2.070.0/dmd.2.070.0.linux.tar.xz",
       sha256 = "42f48db8716f523076e881151f631e741342012881ec9b57353544ed46c4f774",
       build_file_content = DMD_BUILD_FILE,
   )
 
   native.new_http_archive(
       name = "dmd_darwin_x86_64",
-      url = "http://downloads.dlang.org/releases/2.x/2.070.0/dmd.2.070.0.osx.tar.xz",
+      url = "http://bazel-mirror.storage.googleapis.com/downloads.dlang.org/releases/2.x/2.070.0/dmd.2.070.0.osx.tar.xz",
       sha256 = "c1dd14ded8e099dcb2f136379013959b07790249f440010d556e67ff59fe44a0",
       build_file_content = DMD_BUILD_FILE,
   )


### PR DESCRIPTION
I've mirrored your files for guaranteed reliability, courtesy of Google Cloud Storage.

In the future, you can mirror these files too with the following command. Although you need to ask @damienmg for write access to the bucket. Or just email me the URL you want mirrored and I'll happily do it.

```bash
bzmirror() {
  local url="${1:?url}"
  if [[ "${url}" =~ ^([^:]+):([^:]+):([^:]+)$ ]]; then
    url="http://repo1.maven.org/maven2/${BASH_REMATCH[1]//.//}/${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.jar"
  fi
  local dest="gs://bazel-mirror/${url#http*//}"
  local desturl="http://bazel-mirror.storage.googleapis.com/${url#http*//}"
  local name="$(basename "${dest}")"
  wget -O "/tmp/${name}" "${url}" || return 1
  gsutil cp -a public-read "/tmp/${name}" "${dest}" || return 1
  gsutil setmeta -h 'Cache-Control:public, max-age=31536000' "${dest}" || return 1
  curl -I "${desturl}"
  echo
  sha256sum "/tmp/${name}"
  echo "${desturl}"
  rm "/tmp/${name}" || return 1
}
```