### PR TITLE
Add sources to import files when generating a d action

### DIFF
--- a/d/d.bzl
+++ b/d/d.bzl
@@ -499,6 +499,8 @@ filegroup(
     srcs = glob([
         "dmd2/src/druntime/import/*.*",
         "dmd2/src/druntime/import/**/*.*",
+        "dmd2/src/druntime/src/*.*",
+        "dmd2/src/druntime/src/**/*.*",
     ]),
 )
 """


### PR DESCRIPTION
Theses sources seems to be needed on OS X.
See http://ci.bazel.io/job/rules_d/BAZEL_VERSION=HEAD,PLATFORM_NAME=darwin-x86_64/254/console