### PR TITLE
Use redundant URLs for external downloads

### DIFF
--- a/d/d.bzl
+++ b/d/d.bzl
@@ -515,14 +515,20 @@ filegroup(
 def d_repositories():
   native.new_http_archive(
       name = "dmd_linux_x86_64",
-      url = "http://bazel-mirror.storage.googleapis.com/downloads.dlang.org/releases/2.x/2.070.0/dmd.2.070.0.linux.tar.xz",
+      urls = [
+          "http://bazel-mirror.storage.googleapis.com/downloads.dlang.org/releases/2.x/2.070.0/dmd.2.070.0.linux.tar.xz",
+          "http://downloads.dlang.org/releases/2.x/2.070.0/dmd.2.070.0.linux.tar.xz",
+      ],
       sha256 = "42f48db8716f523076e881151f631e741342012881ec9b57353544ed46c4f774",
       build_file_content = DMD_BUILD_FILE,
   )
 
   native.new_http_archive(
       name = "dmd_darwin_x86_64",
-      url = "http://bazel-mirror.storage.googleapis.com/downloads.dlang.org/releases/2.x/2.070.0/dmd.2.070.0.osx.tar.xz",
+      urls = [
+          "http://bazel-mirror.storage.googleapis.com/downloads.dlang.org/releases/2.x/2.070.0/dmd.2.070.0.osx.tar.xz",
+          "http://downloads.dlang.org/releases/2.x/2.070.0/dmd.2.070.0.osx.tar.xz",
+      ],
       sha256 = "c1dd14ded8e099dcb2f136379013959b07790249f440010d556e67ff59fe44a0",
       build_file_content = DMD_BUILD_FILE,
   )


### PR DESCRIPTION
Certain countries have firewalls that don't allow users to download open source
files via mirrors. It's now possible for us to give Bazel the original failover
URL thanks to https://github.com/bazelbuild/bazel/commit/ed7ced0018dc5c5ebd6fc8afc7158037ac1df00d