### PR TITLE
Fix d.bzl

### DIFF
--- a/d/d.bzl
+++ b/d/d.bzl
@@ -460,7 +460,7 @@ _d_docs_attrs = {
 
 d_docs = rule(
     _d_docs_impl,
-    attrs = dict(_d_common_attrs.items() + _d_compile_attrs.items()),
+    attrs = dict(_d_docs_attrs.items() + _d_compile_attrs.items()),
     outputs = {
         "d_docs": "%{name}-docs.zip",
     },


### PR DESCRIPTION
Fix a typo introduced in 32f8534c0e8bd4e7e578a4a0f5ba81820a17fc30

Fixes https://github.com/bazelbuild/bazel/issues/5384