### PR TITLE
Support receiving File to srcs declared with ctx.action.declare_directory

### DIFF
--- a/tests/directory_srcs/BUILD
+++ b/tests/directory_srcs/BUILD
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_d//d:d.bzl", "d_test")
+load("@io_bazel_rules_d//tests/directory_srcs:directory_generator.bzl", "directory_generator")
+
+# Provides a single declared directory File as its output in Default Info,
+# containing a copy of all srcs. This is similar to capturing the output of the
+# D protoc plugin as a single directory, for example.
+directory_generator(
+    name = "dir_gen",
+    srcs = ["main.d"],
+)
+
+# Test that consuming a declared directory in the srcs attribute is correctly
+# expanded to the contained files.
+d_test(
+    name = "directory_srcs",
+    srcs = ["dir_gen"],
+)

--- a/tests/directory_srcs/directory_generator.bzl
+++ b/tests/directory_srcs/directory_generator.bzl
@@ -1,0 +1,26 @@
+def directory_generator_impl(ctx):
+    # Declare a directory rather than a file and copy all sources
+    out_dir = ctx.actions.declare_directory(ctx.label.name)
+    ctx.actions.run_shell(
+        inputs = ctx.files.srcs,
+        outputs = [out_dir],
+        command = "cp {} '{}'".format(
+            ' '.join(["'" + f.path + "'" for f in ctx.files.srcs]),
+            out_dir.path
+        ),
+    )
+
+    # Return the directory File object as the default info files.
+    return [
+        DefaultInfo(
+            files = depset([out_dir]),
+        )
+    ]
+
+
+directory_generator = rule(
+    implementation = directory_generator_impl,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True)
+    },
+)

--- a/tests/directory_srcs/main.d
+++ b/tests/directory_srcs/main.d
@@ -1,0 +1,4 @@
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
Presently, if the `srcs` attr receives a generated `File` declared with `ctx.actions.declare_directory` the directory path is passed directly to the compiler, which fails. By using `ctx.actions.args` we get the directory contents auto-expanded:

> Each directory File item is replaced by all Files recursively contained in that directory, unless expand_directories=False is specified.

https://docs.bazel.build/versions/master/skylark/lib/Args.html#add_all

For context, the D protoc plugin produces non-predictable outputs, which makes `declare_directory` necessary, rather than `declare_file`. To support building the generated files, rules_d needs to support both file and directory File to its srcs attr.