### PR TITLE
Fix import path generation for dependent workspaces and workspace root

### DIFF
--- a/d/d.bzl
+++ b/d/d.bzl
@@ -17,7 +17,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def _is_windows(ctx):
-    return ctx.configuration.host_path_separator == ';'
+    return ctx.configuration.host_path_separator == ";"
 
 def a_filetype(ctx, files):
     lib_suffix = ".lib" if _is_windows(ctx) else ".a"
@@ -66,7 +66,7 @@ def _format_version(name):
 
 def _build_import(label, im):
     """Builds the import path under a specific label"""
-    import_path = ''
+    import_path = ""
     if label.workspace_root:
         import_path += label.workspace_root + "/"
     if label.package:
@@ -98,10 +98,12 @@ def _build_link_arglist(ctx, objs, out, depinfo):
     """Returns a list of strings constituting the D link command arguments."""
     toolchain = _d_toolchain(ctx)
     return (
-        (["-m64",
-          "-L/DEFAULTLIB:user32",
-          "-L/NODEFAULTLIB:libcmt",
-          "-L/DEFAULTLIB:msvcrt",] if _is_windows(ctx) else []) +
+        ([
+            "-m64",
+            "-L/DEFAULTLIB:user32",
+            "-L/NODEFAULTLIB:libcmt",
+            "-L/DEFAULTLIB:msvcrt",
+        ] if _is_windows(ctx) else []) +
         ["-of" + out.path] +
         toolchain.link_flags +
         [f.path for f in depset(transitive = [depinfo.libs, depinfo.transitive_libs]).to_list()] +

--- a/d/d.bzl
+++ b/d/d.bzl
@@ -64,8 +64,8 @@ def _format_version(name):
     """Formats the string name to be used in a --version flag."""
     return name.replace("-", "_")
 
-def _build_import(ctx, label, im)
-    """Builds the import paths for a specific label"""
+def _build_import(label, im):
+    """Builds the import path under a specific label"""
     import_path = ''
     if label.workspace_root:
         import_path += label.workspace_root + "/"
@@ -86,7 +86,7 @@ def _build_compile_arglist(ctx, out, depinfo, extra_flags = []):
             "-w",
             "-g",
         ] +
-        ["-I%s" % _build_import(ctx, ctx.label, im) for im in ctx.attr.imports] +
+        ["-I%s" % _build_import(ctx.label, im) for im in ctx.attr.imports] +
         ["-I%s" % im for im in depinfo.imports] +
         toolchain.import_flags +
         ["-version=Have_%s" % _format_version(ctx.label.name)] +
@@ -149,7 +149,7 @@ def _setup_deps(ctx, deps, name, working_dir):
             transitive_d_srcs.append(dep.transitive_d_srcs)
             versions += dep.versions + ["Have_%s" % _format_version(dep.label.name)]
             link_flags.extend(dep.link_flags)
-            imports += [_build_import(ctx, dep.label, im) for im in dep.imports]
+            imports += [_build_import(dep.label, im) for im in dep.imports]
 
         elif hasattr(dep, "d_srcs"):
             # The dependency is a d_source_library.
@@ -157,7 +157,7 @@ def _setup_deps(ctx, deps, name, working_dir):
             transitive_d_srcs.append(dep.transitive_d_srcs)
             transitive_libs.append(dep.transitive_libs)
             link_flags += ["-L%s" % linkopt for linkopt in dep.linkopts]
-            imports += [_build_import(ctx, dep.label, im) for im in dep.imports]
+            imports += [_build_import(dep.label, im) for im in dep.imports]
             versions += dep.versions
 
         elif CcInfo in dep:
@@ -411,7 +411,7 @@ def _d_docs_impl(ctx):
             "-od%s" % objs_dir,
             "-I.",
         ] +
-        ["-I%s" % _build_import(ctx, ctx.label, im) for im in target.imports] +
+        ["-I%s" % _build_import(ctx.label, im) for im in target.imports] +
         toolchain.import_flags +
         [src.path for src in target.srcs] +
         [

--- a/d/d.bzl
+++ b/d/d.bzl
@@ -64,6 +64,16 @@ def _format_version(name):
     """Formats the string name to be used in a --version flag."""
     return name.replace("-", "_")
 
+def _build_import(ctx, label, import)
+    """Builds the import paths for a specific label"""
+    import_path = ''
+    if label.workspace_root:
+        import_path += label.workspace_root + "/"
+    if label.package:
+        import_path += label.package + "/"
+    import_path += import
+    return import_path
+
 def _build_compile_arglist(ctx, out, depinfo, extra_flags = []):
     """Returns a list of strings constituting the D compile command arguments."""
     toolchain = _d_toolchain(ctx)
@@ -76,7 +86,7 @@ def _build_compile_arglist(ctx, out, depinfo, extra_flags = []):
             "-w",
             "-g",
         ] +
-        ["-I%s/%s" % (ctx.label.package, im) for im in ctx.attr.imports] +
+        ["-I%s" % _build_import(ctx, ctx.label, im) for im in ctx.attr.imports] +
         ["-I%s" % im for im in depinfo.imports] +
         toolchain.import_flags +
         ["-version=Have_%s" % _format_version(ctx.label.name)] +
@@ -139,7 +149,7 @@ def _setup_deps(ctx, deps, name, working_dir):
             transitive_d_srcs.append(dep.transitive_d_srcs)
             versions += dep.versions + ["Have_%s" % _format_version(dep.label.name)]
             link_flags.extend(dep.link_flags)
-            imports += ["%s/%s" % (dep.label.package, im) for im in dep.imports]
+            imports += [_build_import(ctx, dep.label, im) for im in dep.imports]
 
         elif hasattr(dep, "d_srcs"):
             # The dependency is a d_source_library.
@@ -147,7 +157,7 @@ def _setup_deps(ctx, deps, name, working_dir):
             transitive_d_srcs.append(dep.transitive_d_srcs)
             transitive_libs.append(dep.transitive_libs)
             link_flags += ["-L%s" % linkopt for linkopt in dep.linkopts]
-            imports += ["%s/%s" % (dep.label.package, im) for im in dep.imports]
+            imports += [_build_import(ctx, dep.label, im) for im in dep.imports]
             versions += dep.versions
 
         elif CcInfo in dep:
@@ -401,7 +411,7 @@ def _d_docs_impl(ctx):
             "-od%s" % objs_dir,
             "-I.",
         ] +
-        ["-I%s/%s" % (ctx.label.package, im) for im in target.imports] +
+        ["-I%s" % _build_import(ctx, ctx.label, im) for im in target.imports] +
         toolchain.import_flags +
         [src.path for src in target.srcs] +
         [

--- a/d/d.bzl
+++ b/d/d.bzl
@@ -64,14 +64,14 @@ def _format_version(name):
     """Formats the string name to be used in a --version flag."""
     return name.replace("-", "_")
 
-def _build_import(ctx, label, import)
+def _build_import(ctx, label, im)
     """Builds the import paths for a specific label"""
     import_path = ''
     if label.workspace_root:
         import_path += label.workspace_root + "/"
     if label.package:
         import_path += label.package + "/"
-    import_path += import
+    import_path += im
     return import_path
 
 def _build_compile_arglist(ctx, out, depinfo, extra_flags = []):


### PR DESCRIPTION
Previously, a `d_library`/`d_source_library` could not be used across a workspace boundary, such as when depending on a library created by a dependency. This was because the generated import paths would be incorrect and the modules would therefore not be found. This also prevented use of libraries in the root of a workspace from working correctly, as the import path would end up as an absolute path due to `ctx.label.package` being empty.

This change updates how the import arguments are created, to ensure that we don't end up with absolute paths and that the workspace root is taken into account.