### PR TITLE
Migrate to modern linker input API.

### DIFF
--- a/d/d.bzl
+++ b/d/d.bzl
@@ -329,18 +329,17 @@ def _get_libs_for_static_executable(dep):
     Returns:
       A list of File instances, these are the libraries used for linking.
     """
-    libraries_to_link = dep[CcInfo].linking_context.libraries_to_link.to_list()
-
     libs = []
-    for library_to_link in libraries_to_link:
-        if library_to_link.static_library != None:
-            libs.append(library_to_link.static_library)
-        elif library_to_link.pic_static_library != None:
-            libs.append(library_to_link.pic_static_library)
-        elif library_to_link.interface_library != None:
-            libs.append(library_to_link.interface_library)
-        elif library_to_link.dynamic_library != None:
-            libs.append(library_to_link.dynamic_library)
+    for li in dep[CcInfo].linking_context.linker_inputs.to_list():
+        for library_to_link in li.libraries:
+            if library_to_link.static_library != None:
+                libs.append(library_to_link.static_library)
+            elif library_to_link.pic_static_library != None:
+                libs.append(library_to_link.pic_static_library)
+            elif library_to_link.interface_library != None:
+                libs.append(library_to_link.interface_library)
+            elif library_to_link.dynamic_library != None:
+                libs.append(library_to_link.dynamic_library)
     return libs
 
 def _d_source_library_impl(ctx):


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/10860.