### PR TITLE
Fix windows build

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -16,8 +16,14 @@ platforms:
     test_targets:
     - "..."
   windows:
+    build_flags:
+    - "--action_env=PROGRAMFILES(X86)"
+    - "--nodistinct_host_configuration"
     build_targets:
     - "..."
+    test_flags:
+    - "--action_env=PROGRAMFILES(X86)"
+    - "--nodistinct_host_configuration"
     test_targets:
     - "..."
     # Disabled because sh_test needs --enable_runfiles.


### PR DESCRIPTION
Fix windows build by exporting `PROGRAMFILES(X86)` env to allow dmd to find the VC++ runtime libs.