### PR TITLE
Refactor to use toolchains (hence enabling LDC support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ http_archive(
     strip_prefix = "rules_d-bcf137e3c9381545ce54715632bc1d31c51ee4da",
 )
 
-load("@io_bazel_rules_d//d:d.bzl", "d_repositories")
-d_repositories()
+load("@io_bazel_rules_d//d:repositories.bzl", "rules_d_toolchains")
+rules_d_toolchains()
+# rules_d_toolchains(ctype = "ldc") # If you want to use LDC instead of DMD
 ```
 
 ## Roadmap

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,20 @@
 workspace(name = "io_bazel_rules_d")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "bazel_skylib",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.3.0/bazel-skylib-1.3.0.tar.gz",
+    ],
+    sha256 = "74d544d96f4a5bb630d465ca8bbcfe231e3594e5aae57e1edbf17a6eb3ca2506",
+)
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+bazel_skylib_workspace()
+
 load("@io_bazel_rules_d//d:d.bzl", "d_repositories")
 d_repositories()
+
+register_toolchains(
+    "//d:dmd_linux_x86_64_toolchain",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,9 +12,5 @@ http_archive(
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 bazel_skylib_workspace()
 
-load("@io_bazel_rules_d//d:d.bzl", "d_repositories")
-d_repositories()
-
-register_toolchains(
-    "//d:dmd_linux_x86_64_toolchain",
-)
+load("@io_bazel_rules_d//d:repositories.bzl", "rules_d_toolchains")
+rules_d_toolchains()

--- a/d/BUILD
+++ b/d/BUILD
@@ -17,6 +17,16 @@ d_toolchain(
     druntime_src = "@dmd_linux_x86_64//:druntime_src",
 )
 
+d_toolchain(
+    name = "ldc_linux_x86_64",
+    d_compiler = "@ldc_linux_x86_64//:ldc2",
+    libphobos = "@ldc_linux_x86_64//:libphobos2",
+    libphobos_src = "@ldc_linux_x86_64//:phobos_src",
+    druntime = "@ldc_linux_x86_64//:druntime",
+    druntime_src = "@ldc_linux_x86_64//:druntime_src",
+    ctype = "ldc",
+)
+
 toolchain(
     name = "dmd_linux_x86_64_toolchain",
     exec_compatible_with = [
@@ -28,6 +38,20 @@ toolchain(
         "@platforms//cpu:x86_64",
     ],
     toolchain = ":dmd_linux_x86_64",
+    toolchain_type = D_TOOLCHAIN,
+)
+
+toolchain(
+    name = "ldc_linux_x86_64_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":ldc_linux_x86_64",
     toolchain_type = D_TOOLCHAIN,
 )
 

--- a/d/BUILD
+++ b/d/BUILD
@@ -1,57 +1,33 @@
 package(default_visibility = ["//visibility:public"])
 
+load("//d:toolchain.bzl", "D_TOOLCHAIN", "d_toolchain")
+
+toolchain_type(name = "toolchain_type")
+
 filegroup(
     name = "srcs",
     srcs = glob(["**"]),
 )
 
-config_setting(
-    name = "darwin",
-    values = {"host_cpu": "darwin"},
+d_toolchain(
+    name = "dmd_linux_x86_64",
+    d_compiler = "@dmd_linux_x86_64//:dmd",
+    libphobos = "@dmd_linux_x86_64//:libphobos2",
+    libphobos_src = "@dmd_linux_x86_64//:phobos_src",
+    druntime_src = "@dmd_linux_x86_64//:druntime_src",
 )
 
-config_setting(
-    name = "k8",
-    values = {"host_cpu": "k8"},
+toolchain(
+    name = "dmd_linux_x86_64_toolchain",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    toolchain = ":dmd_linux_x86_64",
+    toolchain_type = D_TOOLCHAIN,
 )
 
-config_setting(
-    name = "x64_windows",
-    values = {"host_cpu": "x64_windows"},
-)
-
-filegroup(
-    name = "dmd",
-    srcs = select({
-        ":darwin": ["@dmd_darwin_x86_64//:dmd"],
-        ":k8": ["@dmd_linux_x86_64//:dmd"],
-        ":x64_windows": ["@dmd_windows_x86_64//:dmd"],
-    }),
-)
-
-filegroup(
-    name = "libphobos2",
-    srcs = select({
-        ":darwin": ["@dmd_darwin_x86_64//:libphobos2"],
-        ":k8": ["@dmd_linux_x86_64//:libphobos2"],
-        ":x64_windows": ["@dmd_windows_x86_64//:libphobos2"],
-    }),
-)
-
-filegroup(
-    name = "phobos-src",
-    srcs = select({
-        ":darwin": ["@dmd_darwin_x86_64//:phobos-src"],
-        ":k8": ["@dmd_linux_x86_64//:phobos-src"],
-        ":x64_windows": ["@dmd_windows_x86_64//:phobos-src"],
-    }),
-)
-
-filegroup(
-    name = "druntime-import-src",
-    srcs = select({
-        ":darwin": ["@dmd_darwin_x86_64//:druntime-import-src"],
-        ":k8": ["@dmd_linux_x86_64//:druntime-import-src"],
-        ":x64_windows": ["@dmd_windows_x86_64//:druntime-import-src"],
-    }),
-)

--- a/d/DMD.bzl
+++ b/d/DMD.bzl
@@ -23,7 +23,7 @@ cc_import(
         "@bazel_tools//src/conditions:darwin": "osx/lib/dmd",
         "@bazel_tools//src/conditions:linux_x86_64": "linux/lib64/libphobos2.a",
         "@bazel_tools//src/conditions:windows_x64": "windows/lib64/dmd.exe",
-    })
+    }),
 )
 
 filegroup(

--- a/d/DMD.bzl
+++ b/d/DMD.bzl
@@ -1,0 +1,40 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+native_binary(
+    name = "dmd",
+    out = "dmdcopy.exe",
+    src = select({
+        "@bazel_tools//src/conditions:darwin": "osx/bin/dmd",
+        "@bazel_tools//src/conditions:linux_x86_64": "linux/bin64/dmd",
+        "@bazel_tools//src/conditions:windows_x64": "windows/bin64/dmd.exe",
+    }),
+)
+
+cc_import(
+    name = "libphobos2",
+    shared_library = select({
+        "@bazel_tools//src/conditions:darwin": "osx/lib/dmd",
+        "@bazel_tools//src/conditions:linux_x86_64": "linux/lib64/libphobos2.so",
+        "@bazel_tools//src/conditions:windows_x64": "windows/lib64/dmd.exe",
+    }),
+    static_library = select({
+        "@bazel_tools//src/conditions:darwin": "osx/lib/dmd",
+        "@bazel_tools//src/conditions:linux_x86_64": "linux/lib64/libphobos2.a",
+        "@bazel_tools//src/conditions:windows_x64": "windows/lib64/dmd.exe",
+    })
+)
+
+filegroup(
+    name = "phobos_src",
+    srcs = glob(["src/phobos/**/*.*"]),
+)
+
+filegroup(
+    name = "druntime_src",
+    srcs = glob([
+        "src/druntime/import/*.*",
+        "src/druntime/import/**/*.*",
+    ]),
+)

--- a/d/LDC.bzl
+++ b/d/LDC.bzl
@@ -1,0 +1,61 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+native_binary(
+    name = "ldc2",
+    out = "ldc2copy.exe",
+    src = select({
+        "@bazel_tools//src/conditions:darwin": "bin/ldc2",
+        "@bazel_tools//src/conditions:linux_x86_64": "bin/ldc2",
+        "@bazel_tools//src/conditions:windows_x64": "bin/ldc2.exe",
+    }),
+)
+
+cc_import(
+    name = "libphobos2",
+    shared_library = select({
+        "@bazel_tools//src/conditions:darwin": "osx/lib/dmd",
+        "@bazel_tools//src/conditions:linux_x86_64": "lib/libphobos2-ldc-shared.so",
+        "@bazel_tools//src/conditions:windows_x64": "lib/phobos2-ldc-shared.lib",
+    }),
+    static_library = select({
+        "@bazel_tools//src/conditions:darwin": "osx/lib/dmd",
+        "@bazel_tools//src/conditions:linux_x86_64": "lib/libphobos2-ldc.a",
+        "@bazel_tools//src/conditions:windows_x64": "lib/phobos2-ldc.lib",
+    }),
+)
+
+cc_import(
+    name = "druntime",
+    shared_library = select({
+        "@bazel_tools//src/conditions:darwin": "osx/lib/dmd",
+        "@bazel_tools//src/conditions:linux_x86_64": "lib/libdruntime-ldc-shared.so",
+        "@bazel_tools//src/conditions:windows_x64": "lib/druntime-ldc-shared.lib",
+    }),
+    static_library = select({
+        "@bazel_tools//src/conditions:darwin": "osx/lib/dmd",
+        "@bazel_tools//src/conditions:linux_x86_64": "lib/libdruntime-ldc.a",
+        "@bazel_tools//src/conditions:windows_x64": "lib/druntime-ldc.lib",
+    }),
+)
+
+filegroup(
+    name = "phobos_src",
+    srcs = glob([
+        "import/std/**/*.*",
+        "import/std/*.*",
+        "import/etc/**/*.*",
+        "import/etc/*.*",
+    ]),
+)
+
+filegroup(
+    name = "druntime_src",
+    srcs = glob([
+        "import/core/**/*.*",
+        "import/core/*.*",
+        "import/ldc/**/*.*",
+        "import/ldc/*.*",
+    ]),
+)

--- a/d/repositories.bzl
+++ b/d/repositories.bzl
@@ -1,0 +1,98 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_skylib//lib:versions.bzl", "versions")
+
+DMD_BUILD_FILE = "//d:DMD.bzl"
+LDC_BUILD_FILE = "//d:LDC.bzl"
+DMD_STRIP_PREFIX = "dmd2"
+
+def fetch_and_register_dmd(version = None):
+    if version == None:
+        http_archive(
+            name = "dmd_linux_x86_64",
+            urls = [
+                "https://downloads.dlang.org/releases/2.x/2.102.1/dmd.2.102.1.linux.tar.xz",
+            ],
+            sha256 = "f3f62fd7357d9c0c0349c7b96721d6734fe8285c0f32a37649d378c8abb0e9eb",
+            strip_prefix = DMD_STRIP_PREFIX,
+            build_file = DMD_BUILD_FILE,
+        )
+
+        http_archive(
+            name = "dmd_darwin_x86_64",
+            urls = [
+                "https://downloads.dlang.org/releases/2.x/2.102.1/dmd.2.102.1.osx.tar.xz",
+            ],
+            sha256 = "300d309a2b71e95404f58e14a23daf342f47cc8608476a0b6414d356485df2bc",
+            strip_prefix = DMD_STRIP_PREFIX,
+            build_file = DMD_BUILD_FILE,
+        )
+
+        http_archive(
+            name = "dmd_windows_x86_64",
+            urls = [
+                "https://downloads.dlang.org/releases/2.x/2.102.1/dmd.2.102.1.windows.zip",
+            ],
+            sha256 = "a263ffbf6232288fa093c71a43a5cc1cd09ef5a75e7eca385ece16606c245090",
+            strip_prefix = DMD_STRIP_PREFIX,
+            build_file = DMD_BUILD_FILE,
+        )
+
+        native.register_toolchains(
+            "//d:dmd_linux_x86_64_toolchain",
+        )
+    elif versions.is_at_least("2.0.0", version):
+        http_archive(
+            name = "dmd_linux_x86_64",
+            urls = [
+                "https://downloads.dlang.org/releases/2.x/{version}/dmd.{version}.linux.tar.xz".format(version = version),
+            ],
+            strip_prefix = DMD_STRIP_PREFIX,
+            build_file = DMD_BUILD_FILE,
+        )
+
+        http_archive(
+            name = "dmd_darwin_x86_64",
+            urls = [
+                "https://downloads.dlang.org/releases/2.x/{version}/dmd.{version}.osx.tar.xz".format(version = version),
+            ],
+            strip_prefix = DMD_STRIP_PREFIX,
+            build_file = DMD_BUILD_FILE,
+        )
+
+        http_archive(
+            name = "dmd_windows_x86_64",
+            urls = [
+                "https://downloads.dlang.org/releases/2.x/{version}/dmd.{version}.windows.zip".format(version = version),
+            ],
+            strip_prefix = DMD_STRIP_PREFIX,
+            build_file = DMD_BUILD_FILE,
+        )
+
+        native.register_toolchains(
+            "//d:dmd_linux_x86_64_toolchain",
+        )
+    else:
+        fail("Sorry, only DMD 2 is supported, but got %s. Maybe consider switching to D2?" % version)
+
+def fetch_and_register_ldc():
+    http_archive(
+        name = "ldc_linux_x86_64",
+        urls = [
+            "https://github.com/ldc-developers/ldc/releases/download/v1.31.0/ldc2-1.31.0-linux-x86_64.tar.xz",
+        ],
+        sha256 = "7dbd44786c0772ec41890a8c03e22b0985d6ef547c40943dd56bc6be21cf4d98",
+        strip_prefix = "ldc2-1.31.0-linux-x86_64",
+        build_file = LDC_BUILD_FILE,
+    )
+
+    native.register_toolchains(
+        "//d:ldc_linux_x86_64_toolchain",
+    )
+
+def rules_d_toolchains(ctype = "dmd", version = None):
+    if ctype == "dmd":
+        fetch_and_register_dmd(version = version)
+    elif ctype == "ldc":
+        fetch_and_register_ldc()
+    else:
+        fail("Only \"dmd\" and \"ldc\" compilers are supported at this moment.")

--- a/d/toolchain.bzl
+++ b/d/toolchain.bzl
@@ -10,6 +10,7 @@ def _d_toolchain_impl(ctx):
         libphobos_src = ctx.attr.libphobos_src,
         druntime = ctx.attr.druntime,
         druntime_src = ctx.attr.druntime_src,
+        ctype = ctx.attr.ctype,
     )
     return [toolchain_info]
 
@@ -29,6 +30,10 @@ d_toolchain = rule(
         "libphobos_src": attr.label(),
         "druntime": attr.label(),
         "druntime_src": attr.label(),
+        "ctype": attr.string(
+            default = "dmd",
+            values = ["dmd", "ldc"]
+        ),
     }
 )
 

--- a/d/toolchain.bzl
+++ b/d/toolchain.bzl
@@ -1,0 +1,34 @@
+D_TOOLCHAIN = "@//d:toolchain_type"
+
+def _d_toolchain_impl(ctx):
+    toolchain_info = platform_common.ToolchainInfo(
+        name = ctx.label.name,
+        d_compiler = ctx.attr.d_compiler,
+        link_flags = ctx.attr.link_flags,
+        import_flags = ctx.attr.import_flags,
+        libphobos = ctx.attr.libphobos,
+        libphobos_src = ctx.attr.libphobos_src,
+        druntime = ctx.attr.druntime,
+        druntime_src = ctx.attr.druntime_src,
+    )
+    return [toolchain_info]
+
+d_toolchain = rule(
+    _d_toolchain_impl,
+    attrs = {
+        "d_compiler": attr.label(
+            executable = True,
+            # allow_files = True,
+            cfg = "host",
+        ),
+        "link_flags": attr.string_list(
+            default = [],
+        ),
+        "import_flags": attr.string_list(),
+        "libphobos": attr.label(),
+        "libphobos_src": attr.label(),
+        "druntime": attr.label(),
+        "druntime_src": attr.label(),
+    }
+)
+


### PR DESCRIPTION
The Toolchain refactor is mostly done, but I'm a bit stuck on how to implement an [idiomatic `rules_d_toolchain()` macro](https://bazel.build/rules/deploying?hl=en#registering_toolchains) to use in `WORKSPACE` or as a `bzlmod` extension. Basically, I want users to be able to do something like this:
```starlark
# Some BUILD file
d_library(
    name = "hello",
    srcs = ["source/hello.d"],
    dopts = select({
        "@rules_d//compiler:dmd": ["-shared"],
        "@rules_d//compiler:ldc": ["--shared"],
    }),
)
```
but in the `WORKSPACE` file they'll do something like this to register the toolchain:
```starlark
# WORKSPACE
rules_d_toolchain(
   compiler = "dmd" # or "ldc", or maybe even "gdc" in the future
   version = "102.2.1" # optionally specify version
)
```
It'd be awesome if someone could provide some input on how this may be possible. If this is too much of a hassle, then I guess I'll drop LDC support for now and just leave the toolchain stuff in this PR.

Toolchain support has been tested and works well on Unix machines. Haven't got the chance to test on Windows yet. Additionally, it seems like Windows build is broken even before this PR anyway.